### PR TITLE
Set JVM options to allow java.lang

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 // Default gatlingRun configuration
 gatlingRun {
-    jvmArgs = ['-Xms4G', '-Xmx8G']
+    jvmArgs = ['-Xms4G', '-Xmx8G','--add-opens', 'java.base/java.lang=ALL-UNNAMED']
     simulationClassName = System.getenv("SimulationBlock")
     doFirst {
         println "Running simulation: " + simulationClassName


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###
Gatling 3.13 added report generation changes that requires `--add-opens=java.base/java.lang=ALL-UNNAMED` JVM option as Java 17+ blocks this by default. 

This allowance should be set by Gatling by default but because we already manually change jvmArgs we need to add this as an option. Source for Gatling change https://docs.gatling.io/release-notes/gatling/upgrading/3.12-to-3.13/?utm_source=chatgpt.com 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
